### PR TITLE
Fix failing unit tests test_messenger_sends_to_additional_emails and est_changes_default_when_new_signature_is_created_as_defaul

### DIFF
--- a/tests/unit/messenger_compose_test.php
+++ b/tests/unit/messenger_compose_test.php
@@ -227,7 +227,9 @@ class block_quickmail_messenger_compose_testcase extends advanced_testcase {
         $this->assertEquals('Hello world', $this->email_in_sink_attr($sink, 7, 'subject'));
         $this->assertTrue($this->email_in_sink_body_contains($sink, 7, 'This is one fine body.'));
         $this->assertEquals(get_config('moodle', 'noreplyaddress'), $this->email_in_sink_attr($sink, 7, 'from'));
-        $this->assertEquals('additional@three.com', $this->email_in_sink_attr($sink, 7, 'to'));
+        $this->assertContains('additional@one.com', $this->email_in_sink_attr_all($sink, 'to'));
+        $this->assertContains('additional@two.com', $this->email_in_sink_attr_all($sink, 'to'));
+        $this->assertContains('additional@three.com', $this->email_in_sink_attr_all($sink, 'to'));
 
         $this->close_email_sink($sink);
     }

--- a/tests/unit/traits/sends_emails.php
+++ b/tests/unit/traits/sends_emails.php
@@ -53,6 +53,24 @@ trait sends_emails {
         return $message->$attr;
     }
 
+    /**
+     * Gets a list of messages in the sink and builds an array with an attribute provided.
+     *
+     * @param   phpunit_message_sink  $sink   Message sink.
+     * @param   string                $attr   Name of the attribute.
+     * @return  array                         List of the attributes.
+     */
+    public function email_in_sink_attr_all($sink, $attr) {
+        $result = [];
+        $messages = $sink->get_messages();
+        foreach ($messages as $message) {
+            if (!empty($message->$attr)) {
+                $result[] = $message->$attr;
+            }
+        }
+        return $result;
+    }
+
     public function email_in_sink_body_contains($sink, $index, $bodytext) {
         $messages = $sink->get_messages();
 


### PR DESCRIPTION
The branch fails two unit tests. They are mentioned and fixed in the upstream public repo.
*https://github.com/lsuonline/lsuce-block_quickmail/issues/28
*https://github.com/lsuonline/lsuce-block_quickmail/issues/30


