### PR TITLE
Fix Issue #106

### DIFF
--- a/classes/persistents/message.php
+++ b/classes/persistents/message.php
@@ -183,7 +183,7 @@ class message extends \block_quickmail\persistents\persistent {
         global $DB;
 
         $messageid = $this->get('id');
-        $cuser = $this->get('user_id');
+        $cuser = $DB->get_record('user', ['id' => $this->get('user_id')]);
         $course = $DB->get_record('course', ['id' => $this->get('course_id')]);
         $coursemsg = new message($messageid);
 


### PR DESCRIPTION
**Description:** Add fix from https://github.com/lsuonline/lsuce-block_quickmail/pull/110 for https://github.com/lsuonline/lsuce-block_quickmail/issues/106. Was closed and not added to the upstream plugin's branches.

I was able to replicate this locally on a client site. After applying the fix, the task runs successfully:

```
root:/var/www/wvi# php admin/cli/scheduled_task.php --execute=\\block_quickmail\\tasks\\send_all_ready_messages_task
Execute scheduled task: Send all scheduled Quickmail messages (block_quickmail\tasks\send_all_ready_messages_task)
... started 22:31:02. Current memory use 21.3 MB.
... used 2 dbqueries
... used 0.10733890533447 seconds
Scheduled task complete: Send all scheduled Quickmail messages (block_quickmail\tasks\send_all_ready_messages_task)
root:/var/www/wvi#
```