### PR TITLE
Link to broadcast page when courseid == siteid on qm.php (#130)

### DIFF
--- a/qm.php
+++ b/qm.php
@@ -55,10 +55,14 @@ $qmnode = $coursenode->add(get_string('pluginname', 'block_quickmail'),
 $qmnode->make_active();
 
 // Construct the links.
-$composelink = html_writer::link(new moodle_url('/blocks/quickmail/compose.php',
-                                 array('courseid' => $courseid)),
-                                 block_quickmail_string::get('ms_compose'),
-                                 array('class' => 'qml compose'));
+$composelink = $courseid == SITEID
+    ? html_writer::link(new moodle_url('/blocks/quickmail/broadcast.php'),
+                        block_quickmail_string::get('open_broadcast'),
+                        array('class' => 'qml compose'))
+    : html_writer::link(new moodle_url('/blocks/quickmail/compose.php',
+                        array('courseid' => $courseid)),
+                        block_quickmail_string::get('ms_compose'),
+                        array('class' => 'qml compose'));
 $draftlink = html_writer::link(new moodle_url('/blocks/quickmail/drafts.php',
                                array('courseid' => $courseid)),
                                block_quickmail_string::get('ms_drafts'),


### PR DESCRIPTION
**Description:** Resolves #130. This PR aligns the block content and `qm.php` so that the "Compose message" links to `broadcast.php` when on the site course (ID = 1).

**Testing steps:**
1. Install plugin

_Test existing block functionality_

2. Visit `course/view.php?id=1`
3. Add the `Quickmail` block
4. Confirm that the `Compose message` button links to `broadcast.php`
5. Create or visit a course
6. Add the `Quickmail` block
7. Confirm that the `Compose message` button links to `compose.php`

_Test that `qm.php` now has same behaviour as block functionality regarding "Compose message" button_

8. Visit `blocks/quickmail/qm.php?courseid=1`
9. Confirm that the `Compose message` button links to `broadcast.php`
10. Visit `blocks/quickmail/qm.php?courseid={courseid}`
11. Confirm that the `Compose message` button now links to `compose.php`

You can also test this logging in as a student. All links on `qm.php`, including now the Compose message button, link to pages that require permissions that will fail for students. 